### PR TITLE
Add opts for vis, partitions, and replication to KafkaLoadTester.

### DIFF
--- a/geomesa-quickstart-kafka/geomesa-quickstart-kafka-08/src/main/java/com/example/geomesa/kafka08/KafkaLoadTester.java
+++ b/geomesa-quickstart-kafka/geomesa-quickstart-kafka-08/src/main/java/com/example/geomesa/kafka08/KafkaLoadTester.java
@@ -10,13 +10,13 @@ package com.example.geomesa.kafka08;
 
 import com.vividsolutions.jts.geom.Geometry;
 import com.vividsolutions.jts.geom.Point;
+import org.apache.commons.cli.*;
 import org.geotools.data.DataStore;
 import org.geotools.data.DataStoreFinder;
 import org.geotools.data.simple.SimpleFeatureSource;
 import org.geotools.data.simple.SimpleFeatureStore;
 import org.geotools.feature.DefaultFeatureCollection;
 import org.geotools.feature.simple.SimpleFeatureBuilder;
-import org.apache.commons.cli.*;
 import org.locationtech.geomesa.kafka.KafkaDataStoreHelper;
 import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes;
 import org.locationtech.geomesa.utils.text.WKTUtils$;
@@ -24,6 +24,7 @@ import org.opengis.feature.Property;
 import org.opengis.feature.simple.SimpleFeature;
 import org.opengis.feature.simple.SimpleFeatureType;
 import org.opengis.feature.type.Name;
+
 import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -32,12 +33,17 @@ public class KafkaLoadTester {
     public static final String KAFKA_BROKER_PARAM = "brokers";
     public static final String ZOOKEEPERS_PARAM = "zookeepers";
     public static final String ZK_PATH = "zkPath";
+    public static final String PARTITIONS = "partitions";
+    public static final String REPLICATION = "replication";
+    public static final String VISIBILITY = "visibility";
     public static final String LOAD = "count";
 
     public static final String[] KAFKA_CONNECTION_PARAMS = new String[] {
             KAFKA_BROKER_PARAM,
             ZOOKEEPERS_PARAM,
-            ZK_PATH
+            ZK_PATH,
+            PARTITIONS,
+            REPLICATION
     };
 
     // reads and parse the command line args
@@ -64,11 +70,29 @@ public class KafkaLoadTester {
                 .create(ZK_PATH);
         options.addOption(zkPath);
 
+        Option partitions = OptionBuilder.withArgName(PARTITIONS)
+                .hasArg()
+                .withDescription("Number of partitions to use in Kafka topics")
+                .create(PARTITIONS);
+        options.addOption(partitions);
+
+        Option replication = OptionBuilder.withArgName(REPLICATION)
+                .hasArg()
+                .withDescription("Replication factor to use in Kafka topics")
+                .create(REPLICATION);
+        options.addOption(replication);
+
         Option load = OptionBuilder.withArgName(LOAD)
                 .hasArg()
                 .withDescription("Number of entities to simulate.")
                 .create(LOAD);
         options.addOption(load);
+
+        Option visibility = OptionBuilder.withArgName(VISIBILITY)
+                .hasArg()
+                .withDescription("Visibilities to set on each feature created")
+                .create(VISIBILITY);
+        options.addOption(visibility);
 
         return options;
     }
@@ -77,12 +101,14 @@ public class KafkaLoadTester {
     public static Map<String, String> getKafkaDataStoreConf(CommandLine cmd) {
         Map<String, String> dsConf = new HashMap<>();
         for (String param : KAFKA_CONNECTION_PARAMS) {
-            dsConf.put(param, cmd.getOptionValue(param));
+            String value = cmd.getOptionValue(param);
+            if (value != null)
+                dsConf.put(param, value);
         }
         return dsConf;
     }
 
-    public static SimpleFeature createFeature(SimpleFeatureBuilder builder, int i) {
+    public static SimpleFeature createFeature(SimpleFeatureBuilder builder, int i, String visibility) {
         final String[] PEOPLE_NAMES = {"James", "John", "Peter", "Hannah", "Claire", "Gabriel"};
         final Random random = new Random();
 
@@ -96,7 +122,11 @@ public class KafkaLoadTester {
         builder.add(lat);
         builder.add(new Date()); // dtg
         builder.add(WKTUtils$.MODULE$.read("POINT(" + -180.0 + " " + lat + ")")); // geom
-        return builder.buildFeature(Integer.toString(i));
+        SimpleFeature feat = builder.buildFeature(Integer.toString(i));
+        if (visibility != null) {
+            feat.getUserData().put("geomesa.feature.visibility", visibility);
+        }
+        return feat;
     }
 
     // prints out attribute values for a SimpleFeature
@@ -116,9 +146,17 @@ public class KafkaLoadTester {
         CommandLineParser parser = new BasicParser();
         Options options = getCommonRequiredOptions();
         CommandLine cmd = parser.parse(options, args);
+        String visibility = getVisibility(cmd);
+
+        if (visibility == null) {
+            System.out.println("visibility: null");
+        } else {
+            System.out.println("visibility: '"+visibility+"'");
+        }
 
         // create the producer and consumer KafkaDataStore objects
         Map<String, String> dsConf = getKafkaDataStoreConf(cmd);
+        System.out.println("KDS config: "+dsConf);
         dsConf.put("isProducer", "true");
         DataStore producerDS = DataStoreFinder.getDataStore(dsConf);
         dsConf.put("isProducer", "false");
@@ -161,7 +199,7 @@ public class KafkaLoadTester {
         Integer numFeats = getLoad(cmd);
 
         System.out.println("Building a list of " + numFeats + " SimpleFeatures.");
-        List<SimpleFeature> features = IntStream.range(1, numFeats).mapToObj(i -> createFeature(builder, i)).collect(Collectors.toList());
+        List<SimpleFeature> features = IntStream.range(1, numFeats).mapToObj(i -> createFeature(builder, i, visibility)).collect(Collectors.toList());
 
         // set variables to estimate feature production rate
         Long startTime = null;
@@ -231,5 +269,9 @@ public class KafkaLoadTester {
     public static Integer getLoad(CommandLine cmd) {
         String count = cmd.getOptionValue(LOAD, "1000");
         return Integer.parseInt(count);
+    }
+
+    public static String getVisibility(CommandLine cmd) {
+        return cmd.getOptionValue(VISIBILITY);
     }
 }

--- a/geomesa-quickstart-kafka/geomesa-quickstart-kafka-09/src/main/java/com/example/geomesa/kafka09/KafkaLoadTester.java
+++ b/geomesa-quickstart-kafka/geomesa-quickstart-kafka-09/src/main/java/com/example/geomesa/kafka09/KafkaLoadTester.java
@@ -10,6 +10,7 @@ package com.example.geomesa.kafka09;
 
 import com.vividsolutions.jts.geom.Geometry;
 import com.vividsolutions.jts.geom.Point;
+import org.apache.commons.cli.*;
 import org.geotools.data.DataStore;
 import org.geotools.data.DataStoreFinder;
 import org.geotools.data.simple.SimpleFeatureSource;
@@ -23,7 +24,7 @@ import org.opengis.feature.Property;
 import org.opengis.feature.simple.SimpleFeature;
 import org.opengis.feature.simple.SimpleFeatureType;
 import org.opengis.feature.type.Name;
-import org.apache.commons.cli.*;
+
 import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -32,12 +33,17 @@ public class KafkaLoadTester {
     public static final String KAFKA_BROKER_PARAM = "brokers";
     public static final String ZOOKEEPERS_PARAM = "zookeepers";
     public static final String ZK_PATH = "zkPath";
+    public static final String PARTITIONS = "partitions";
+    public static final String REPLICATION = "replication";
+    public static final String VISIBILITY = "visibility";
     public static final String LOAD = "count";
 
     public static final String[] KAFKA_CONNECTION_PARAMS = new String[] {
             KAFKA_BROKER_PARAM,
             ZOOKEEPERS_PARAM,
-            ZK_PATH
+            ZK_PATH,
+            PARTITIONS,
+            REPLICATION
     };
 
     // reads and parse the command line args
@@ -64,11 +70,29 @@ public class KafkaLoadTester {
                 .create(ZK_PATH);
         options.addOption(zkPath);
 
+        Option partitions = OptionBuilder.withArgName(PARTITIONS)
+                .hasArg()
+                .withDescription("Number of partitions to use in Kafka topics")
+                .create(PARTITIONS);
+        options.addOption(partitions);
+
+        Option replication = OptionBuilder.withArgName(REPLICATION)
+                .hasArg()
+                .withDescription("Replication factor to use in Kafka topics")
+                .create(REPLICATION);
+        options.addOption(replication);
+
         Option load = OptionBuilder.withArgName(LOAD)
                 .hasArg()
                 .withDescription("Number of entities to simulate.")
                 .create(LOAD);
         options.addOption(load);
+
+        Option visibility = OptionBuilder.withArgName(VISIBILITY)
+                .hasArg()
+                .withDescription("Visibilities to set on each feature created")
+                .create(VISIBILITY);
+        options.addOption(visibility);
 
         return options;
     }
@@ -77,12 +101,14 @@ public class KafkaLoadTester {
     public static Map<String, String> getKafkaDataStoreConf(CommandLine cmd) {
         Map<String, String> dsConf = new HashMap<>();
         for (String param : KAFKA_CONNECTION_PARAMS) {
-            dsConf.put(param, cmd.getOptionValue(param));
+            String value = cmd.getOptionValue(param);
+            if (value != null)
+                dsConf.put(param, value);
         }
         return dsConf;
     }
 
-    public static SimpleFeature createFeature(SimpleFeatureBuilder builder, int i) {
+    public static SimpleFeature createFeature(SimpleFeatureBuilder builder, int i, String visibility) {
         final String[] PEOPLE_NAMES = {"James", "John", "Peter", "Hannah", "Claire", "Gabriel"};
         final Random random = new Random();
 
@@ -96,7 +122,11 @@ public class KafkaLoadTester {
         builder.add(lat);
         builder.add(new Date()); // dtg
         builder.add(WKTUtils$.MODULE$.read("POINT(" + -180.0 + " " + lat + ")")); // geom
-        return builder.buildFeature(Integer.toString(i));
+        SimpleFeature feat = builder.buildFeature(Integer.toString(i));
+        if (visibility != null) {
+            feat.getUserData().put("geomesa.feature.visibility", visibility);
+        }
+        return feat;
     }
 
     // prints out attribute values for a SimpleFeature
@@ -116,9 +146,17 @@ public class KafkaLoadTester {
         CommandLineParser parser = new BasicParser();
         Options options = getCommonRequiredOptions();
         CommandLine cmd = parser.parse(options, args);
+        String visibility = getVisibility(cmd);
+
+        if (visibility == null) {
+            System.out.println("visibility: null");
+        } else {
+            System.out.println("visibility: '"+visibility+"'");
+        }
 
         // create the producer and consumer KafkaDataStore objects
         Map<String, String> dsConf = getKafkaDataStoreConf(cmd);
+        System.out.println("KDS config: "+dsConf);
         dsConf.put("isProducer", "true");
         DataStore producerDS = DataStoreFinder.getDataStore(dsConf);
         dsConf.put("isProducer", "false");
@@ -161,7 +199,7 @@ public class KafkaLoadTester {
         Integer numFeats = getLoad(cmd);
 
         System.out.println("Building a list of " + numFeats + " SimpleFeatures.");
-        List<SimpleFeature> features = IntStream.range(1, numFeats).mapToObj(i -> createFeature(builder, i)).collect(Collectors.toList());
+        List<SimpleFeature> features = IntStream.range(1, numFeats).mapToObj(i -> createFeature(builder, i, visibility)).collect(Collectors.toList());
 
         // set variables to estimate feature production rate
         Long startTime = null;
@@ -231,5 +269,9 @@ public class KafkaLoadTester {
     public static Integer getLoad(CommandLine cmd) {
         String count = cmd.getOptionValue(LOAD, "1000");
         return Integer.parseInt(count);
+    }
+
+    public static String getVisibility(CommandLine cmd) {
+        return cmd.getOptionValue(VISIBILITY);
     }
 }


### PR DESCRIPTION
-visibility <vis>    Apply visibilities <vis> to each created feature.
-partitions <n>      Number of partitions to use for each Kafka topic.
-replication <n>     Replication factor for Kafka topics.

Signed-off-by: Matthew Zimmerman matt.zimmerman@ccri.com
