### PR TITLE
Added currator exclusion to hadoop dependency

### DIFF
--- a/geomesa-quickstart-accumulo/pom.xml
+++ b/geomesa-quickstart-accumulo/pom.xml
@@ -44,6 +44,12 @@
         <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-common</artifactId>
+            <exclusions>
+              <exclusion>
+                <groupId>org.apache.curator</groupId>
+                <artifactId>curator-client</artifactId>
+              </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.hadoop</groupId>


### PR DESCRIPTION
Added currator exclusion to allow the Accumulo quickstart to work with Accumulo 1.8.x

Signed-off-by: Austin Heyne <aheyne@ccri.com>